### PR TITLE
Separate data logic from display logic

### DIFF
--- a/src/hubstats/github.clj
+++ b/src/hubstats/github.clj
@@ -1,0 +1,105 @@
+(ns hubstats.github
+  (:require
+    [clojure.data.json :as json]
+    [clj-time.core :as time]
+    [clj-time.format :as time-format])
+  (:import
+    (java.net UnknownHostException)
+    (java.io FileNotFoundException IOException)))
+
+(def date-format (time-format/formatter "yyyy-MM-dd'T'HH:mm:ssZ"))
+
+(defn github-api-events [org repo token page]
+  (json/read-str
+    (slurp
+      (str
+        "https://api.github.com/repos/" org "/" repo "/events" "?access_token=" token "&page=" page))))
+
+(defn events
+  ([org repo token page]
+   (when (< page 100)
+     (try
+       (github-api-events org repo token page)
+       (catch IOException e nil)                            ;TODO Check for HTTP 422? Exception message contains "Server returned HTTP response code: 422 for URL"
+       (catch UnknownHostException e (throw e))
+       (catch FileNotFoundException e (throw e)))))
+  ([org repo token page acc]
+   (let [events (events org repo token page)]
+     (if (nil? events)
+       acc
+       (recur org repo token (inc page) (concat acc events)))))
+  ([org repo token]
+   (events org repo token 1 [])))
+
+(defn- since? [map key date]
+  (time/after?
+    (time-format/parse date-format (get map key))
+    date))
+
+(defn- created-since? [event date]
+  (since? event "created_at" date))
+
+(defn- action [event]
+  (get-in event ["payload" "action"]))
+
+(defn- pr-closed? [event]
+  (= (action event) "closed"))
+
+(defn- pr-opened? [event]
+  (= (action event) "opened"))
+
+(defn- pr-review-comment-evt? [event]
+  (= "PullRequestReviewCommentEvent" (get event "type")))
+
+(defn- pr-event? [event]
+  (= "PullRequestEvent" (get event "type")))
+
+(defn- created? [review-comment]
+  (= (get-in review-comment ["payload" "action"]) "created"))
+
+(defn pr-stats [opts]
+  (let [org (opts :org)
+        repo (opts :repo)
+        token (opts :token)
+        since-date (get opts :since nil)
+        days (Integer/parseInt (get opts :days "0"))
+        weeks (Integer/parseInt (get opts :weeks "1"))
+        date (if since-date
+               (time-format/parse date-format since-date)
+               (time/ago (if (> days 0) (time/days days) (time/weeks weeks))))
+        raw-events (events org repo token)
+        new-raw-events (filter #(created-since? % date) raw-events)]
+    (assoc {}
+      :request {:org   org
+                :repo  repo
+                :since date}
+      :opened {
+               :count (count (filter pr-opened? new-raw-events))
+               :count-by-author
+                      (reverse
+                        (sort-by last
+                                 (->> (filter pr-event? raw-events)
+                                      (filter #(since? % "created_at" date))
+                                      (filter #(= "opened" (get-in % ["payload" "action"])))
+                                      (map #(get-in % ["actor" "login"]))
+                                      frequencies)))
+               }
+      :reviewed {
+                 :count-by-author
+                 (reverse
+                   (sort-by last
+                            (->> (filter pr-review-comment-evt? raw-events)
+                                 (filter created?)
+                                 (filter #(since? % "created_at" date))
+                                 (map #(get-in % ["actor" "login"]))
+                                 frequencies)))
+                 }
+      :closed {:count           (count (filter pr-closed? new-raw-events))
+               :count-by-author (reverse
+                                  (sort-by last
+                                           (->> (filter pr-event? raw-events)
+                                                (filter #(since? % "created_at" date))
+                                                (filter #(= "closed" (get-in % ["payload" "action"])))
+                                                (map #(get-in % ["actor" "login"]))
+                                                frequencies)))}
+      )))

--- a/test/hubstats/core_test.clj
+++ b/test/hubstats/core_test.clj
@@ -1,8 +1,10 @@
 (ns hubstats.core-test
   (:require
-    [clojure.java.io :as io]
-    [clojure.test :refer :all]
-    [hubstats.core :refer :all]
+    [clojure.java.io :refer [resource]]
+    [clojure.string :refer [starts-with?]]
+    [clojure.test :refer [deftest is testing]]
+    [hubstats.core :refer [-main]]
+    [hubstats.github :refer [github-api-events]]
     [clojure.data.json :as json])
   (:import (java.io FileNotFoundException StringWriter)))
 
@@ -11,44 +13,13 @@
   (letfn [(read-json [_ _ _ page]
             (when (= page 1)
               (json/read-str
-                (slurp (io/resource "hubstats/events.json")))))]
+                (slurp (resource "hubstats/events.json")))))]
 
     (testing "Display summary of pull requests"
 
       (binding [*out* (StringWriter.)]
         (with-redefs
           [github-api-events read-json]
-
-          (-main "-o org -r repo")
-
-          (is (clojure.string/starts-with? *out* "pull requests for org/repo")))))
-
-    (testing "Display summary of pull requests with correct counters"
-
-      (binding [*out* (StringWriter.)]
-        (with-redefs
-          [github-api-events read-json]
-
-          (-main "-o softwarevidal -r arthur -s 2016-12-04T00:00:00Z")
-
-          (is (clojure.string/starts-with? *out* "pull requests for softwarevidal/arthur"))
-          (is (clojure.string/includes? *out* "1 opened / 0 closed")))))
-
-    (testing "No errors if GitHub returns no events"
-
-      (binding [*out* (StringWriter.)]
-        (with-redefs
-          [github-api-events (fn [_ _ _ _] (json/read-str ""))]
-
-          (-main "-o org -r repo")
-
-          (is (clojure.string/starts-with? *out* "pull requests for org/repo")))))
-
-    (testing "No errors if GitHub is unreachable"
-
-      (binding [*out* (StringWriter.)]
-        (with-redefs
-          [github-api-events (fn [_ _ _ _] (throw (FileNotFoundException. "not found")))]
 
           (-main "-o org -r repo")
 

--- a/test/hubstats/events.json
+++ b/test/hubstats/events.json
@@ -1,68 +1,81 @@
 [
-  {
-    "id": "1",
-    "type": "PullRequestEvent",
-    "actor": {
-      "id": 1,
-      "login": "alice",
-      "display_login": "alice",
-      "gravatar_id": "",
-    },
-    "repo": {
-      "id": 2,
-      "name": "softwarevidal/fake-repo",
-      "url": "https://localhost/repos/fake-org/fake-repo"
-    },
-    "payload": {
-      "action": "opened",
-      "number": 3,
-      "pull_request": {
-        "merged": false,
-        "mergeable": true,
-        "mergeable_state": "clean",
-        "merged_by": null,
-        "comments": 0,
-        "review_comments": 0,
-        "commits": 1,
-        "additions": 284,
-        "deletions": 27,
-        "changed_files": 9
-      }
-    },
-    "public": false,
-    "created_at": "2016-12-05T16:26:43Z",
-    "org": {
-      "id": 4,
-      "login": "fake-repo",
-      "gravatar_id": ""
-    }
-  },
-  {
-    "id": "2",
-    "type": "PullRequestReviewCommentEvent",
-    "actor": {
-      "id": 5,
-      "login": "bob",
-      "display_login": "bob"
-    },
-    "repo": {
-      "id": 6,
-      "name": "softwarevidal/fake-repo",
-      "url": "https://localhost/repos/softwarevidal/fake-repo"
-    },
-    "payload": {
-      "action": "created",
-      "comment": {
+   {
+      "id": "1",
+      "type": "PullRequestEvent",
+      "actor": {
+         "login": "alice",
+         "display_login": "alice"
       },
-      "pull_request": {
-      }
-    },
-    "public": false,
-    "created_at": "2016-12-05T17:07:39Z",
-    "org": {
-      "id": 7,
-      "login": "fake-repo",
-      "gravatar_id": ""
-    }
-  }
+      "repo": {
+         "id": 2,
+         "name": "softwarevidal/fake-repo"
+      },
+      "payload": {
+         "action": "opened"
+      },
+      "public": false,
+      "created_at": "2016-12-01T16:26:43Z"
+   },
+   {
+      "id": "2",
+      "type": "PullRequestEvent",
+      "actor": {
+         "id": 1,
+         "login": "alice",
+         "display_login": "alice"
+      },
+      "repo": {
+         "id": 2,
+         "name": "softwarevidal/fake-repo"
+      },
+      "payload": {
+         "action": "opened",
+         "number": 3,
+         "pull_request": {
+         }
+      },
+      "created_at": "2016-12-05T16:26:43Z"
+   },
+   {
+      "id": "3",
+      "type": "PullRequestReviewCommentEvent",
+      "actor": {
+         "id": 5,
+         "login": "bob",
+         "display_login": "bob"
+      },
+      "repo": {
+         "id": 6,
+         "name": "softwarevidal/fake-repo"
+      },
+      "payload": {
+         "action": "created",
+         "comment": {
+         },
+         "pull_request": {
+         }
+      },
+      "public": false,
+      "created_at": "2016-12-05T17:07:39Z"
+   },
+   {
+      "id": "4",
+      "type": "PullRequestEvent",
+      "actor": {
+         "id": 1,
+         "login": "alice",
+         "display_login": "alice"
+      },
+      "repo": {
+         "id": 2,
+         "name": "softwarevidal/fake-repo"
+      },
+      "payload": {
+         "action": "closed",
+         "number": 3,
+         "pull_request": {
+         }
+      },
+      "created_at": "2016-12-06T10:00:00Z"
+   }
 ]

--- a/test/hubstats/github_test.clj
+++ b/test/hubstats/github_test.clj
@@ -1,0 +1,57 @@
+(ns hubstats.github-test
+  (:require
+    [clojure.java.io :as io]
+    [clojure.test :refer :all]
+    [hubstats.github :refer [github-api-events pr-stats]]
+    [clojure.data.json :as json]))
+
+(deftest github-tests
+
+  (letfn [(read-json [_ _ _ page]
+            (when (= page 1)
+              (json/read-str
+                (slurp (io/resource "hubstats/events.json")))))]
+
+    (testing "Summary of pull requests when some GitHub events"
+      (with-redefs
+        [github-api-events read-json]
+        (pr-stats {:org "myorg" :repo "myrepo" :since "2016-12-04T00:00:00Z"})
+        (is (= {
+                :request  {:org   "myorg"
+                           :repo  "myrepo"
+                           :since "2016-12-04T00:00:00Z"}
+                :opened   {
+                           :count           1
+                           :count-by-author {"alice" 1 "bob" 0}
+                           }
+                :reviewed {
+                           :count           1
+                           :count-by-author {"alice" 0 "bob" 1}
+                           }
+                :closed   {
+                           :count           1
+                           :count-by-author {"alice" 1 "bob" 0}
+                           }
+                })))))
+
+  (testing "Summary of pull requests when no GitHub events"
+    (with-redefs
+      [github-api-events (fn [_ _ _ _] (json/read-str ""))]
+      (pr-stats {:org "org" :repo "repo" :since "2016-12-04T00:00:00Z"})
+      (is (= {
+              :request  {:org   "myorg"
+                         :repo  "myrepo"
+                         :since "2016-12-04T00:00:00Z"}
+              :opened   {
+                         :count           0
+                         :count-by-author {}
+                         }
+              :reviewed {
+                         :count           0
+                         :count-by-author {}
+                         }
+              :closed   {
+                         :count           0
+                         :count-by-author {}
+                         }
+              })))))


### PR DESCRIPTION
Separate data logic (filter and transform GitHub data) from display logic
(output stats in standard output).
It's now:
- easier to reason about 🤔
- easier to test (unit tests replace integration tests) ✅