### PR TITLE
Generate executable via GraalVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.iml
 /lib
 .idea
+hubstats.core

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Examples:
 
 ## Command line installation
 
+### As a Java application (portable)
+
 Create JAR with all dependencies:
 ```shell
 lein uberjar
@@ -74,3 +76,6 @@ On Unix-like systems, you can create an executable via the following command:
 ```
 This executable, which requires Java, can be moved to `/usr/local/bin`, for example.
 
+### As a *nix native executable
+
+Create a native executable via GraalVM running `./generate-executable.sh`. Only works for Linux and macOS.

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Fail on error
+set -e
+
+echo "Build nicokosi/hubstats JAR file:"
+lein uberjar
+
+echo "Install GraalVM via SDKMAN!:"
+curl --silent "https://get.sdkman.io" | bash || echo 'SDKMAN! already installed'
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+GRAALVM_VERSION=19.0.2-grl
+sdkman_auto_answer=true sdk install java $GRAALVM_VERSION > /dev/null
+sdk use java $GRAALVM_VERSION
+
+echo "Build executable from JAR via GraalVM:"
+gu install native-image && \
+native-image \
+    --allow-incomplete-classpath \
+    --force-fallback \
+    --initialize-at-build-time \
+    --no-server \
+    --report-unsupported-elements-at-runtime \
+    -Dclojure.compiler.direct-linking=true \
+    -H:+ReportExceptionStackTraces \
+    -jar ./target/hubstats-0.1.0-SNAPSHOT-standalone.jar \
+    hubstats.core
+
+echo "Executable has been built! ✅
+
+It can be run this way:
+
+ # Show last 10 days stats for GitHub repository docker/containerd:
+ $ ./hubstats.core --organization docker --repository containerd --since-days 10
+
+ # Show all parameters:
+ $ ./hubstats.core"


### PR DESCRIPTION
This [interesting blog post](https://www.innoq.com/en/blog/native-clojure-and-graalvm/
) made me want to try using [GraalVM](http://www.graalvm.org/) in order to generate hubstats' executable.