### PR TITLE
Use 'Authorization' HTTP header instead of 'access_token' query parameter which is deprecated by GitHub

### DIFF
--- a/src/hubstats/github.clj
+++ b/src/hubstats/github.clj
@@ -12,7 +12,10 @@
 (defn github-api-events [org repo token page]
   (let [url (str "https://api.github.com/repos/" org "/" repo "/events?access_token=" token "&page=" page)]
     (json/read-str
-      ((http-client/get url {"Accept" "application/vnd.github.v3+json"}) :body))))
+      ((http-client/get url {
+                             "Authorization" token
+                             "Accept" "application/vnd.github.v3+json"})
+       :body))))
 
 (defn events
   ([org repo token page]


### PR DESCRIPTION
Seems OK:

```sh
lein run --organization softwarevidal --repository arthur --token $GITHUB_TOKEN                                                                    
pull requests for softwarevidal/arthur ->
	since 2020-03-29T10:26:01Z
		14 opened / 13 closed / 8 commented (75 comments)
 		opened per author:  {nicokosi 6, vivianechastagner 3, ohue-ruth 2, jcgay 2, AElMehdiVidal 1}
 		comments per author:  {nicokosi 26, jcgay 22, vivianechastagner 15, AElMehdiVidal 8, ohue-ruth 3, AmauryBchp 1}
 		closed per author:  {nicokosi 5, jcgay 4, vivianechastagner 2, AElMehdiVidal 2}
```