### PR TITLE
⬆ Upgrade GraalVM to 22.0.0.2

### DIFF
--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -9,7 +9,7 @@ lein uberjar
 echo "Install GraalVM via SDKMAN!:"
 curl --silent "https://get.sdkman.io" | bash || echo 'SDKMAN! already installed'
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-GRAALVM_VERSION=21.2.0.r16-grl
+GRAALVM_VERSION=22.0.0.2.r11-grl
 
 sdkman_auto_answer=true \
     sdkman_auto_selfupdate=tr \
@@ -23,7 +23,6 @@ native-image \
     --allow-incomplete-classpath \
     --initialize-at-build-time \
     --no-fallback \
-    --no-server \
     --report-unsupported-elements-at-runtime \
     -Dclojure.compiler.direct-linking=true \
     -H:EnableURLProtocols=https \


### PR DESCRIPTION
See https://www.graalvm.org/22.0.

Notable change:
https://www.graalvm.org/22.0/reference-manual/native-image/BuildOutput/